### PR TITLE
Change mult chr

### DIFF
--- a/include/IntervalNode.hpp
+++ b/include/IntervalNode.hpp
@@ -112,6 +112,7 @@ public:
 Position calculate_median(std::vector<Record> const & records_i)
 {
     std::vector<Position> values{};
+    values.reserve(records_i.size() * 2);
     Position median{};
     for (auto const & r : records_i)
     {

--- a/include/IntervalNode.hpp
+++ b/include/IntervalNode.hpp
@@ -108,6 +108,11 @@ public:
    \brief Calculate the median for a set of records based on the starts and ends of all records.
    \param records_i The list of records to calculate a median off of.
    \return Returns the median value and which chromosome it is in.
+
+   The median is calculated by sorting all of the starts and ends from a list of records. Since each record
+   has a start and end, the list is an even length and the median is the average of the middle two positions.
+   If the middle two positions are from the same chromsome, then they are averaged. If they're from two different
+   chromosomes then averaging is not possible and the right-most is taken.
 */
 Position calculate_median(std::vector<Record> const & records_i)
 {
@@ -131,7 +136,6 @@ Position calculate_median(std::vector<Record> const & records_i)
     {
         median = values[size / 2];
     }
-     // The size of the vector values will always be an even number, therefore the median is just the leftmost.
     return median;
 }
 

--- a/include/Record.hpp
+++ b/include/Record.hpp
@@ -99,9 +99,9 @@ void parse_file(std::filesystem::path const & input_path,
         int32_t position = r.reference_position().value_or(-1);
         Position start = std::make_pair(ref_id, position);
         Position end = std::make_pair(ref_id, position + get_length(r.cigar_sequence()));
-        Record rec{start, end};
         if (ref_id != -1 && position != -1)
         {
+            Record rec{start, end};
             record_list.push_back(std::move(rec));
         }
     }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -15,6 +15,7 @@ struct CmdOptions
    \param start Where the resulting start bamit::Position will go.
    \param end Where the resulting end bamit::Position will go.
    \param options The CmdOptions object storing the start and end strings from the user.
+   \param ref_ids The reference chromosome names, stored in a deque by seqan3.
    \return 0 if the parsing was successful, -1 otherwise.
 */
 int32_t const parse_overlap_query(bamit::Position & start,

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -10,32 +10,39 @@ struct CmdOptions
     std::string end{};
 };
 
+/*!
+   \brief Parse the start and end strings from the given options and put them into the given bamit::Position containers.
+   \param start Where the resulting start bamit::Position will go.
+   \param end Where the resulting end bamit::Position will go.
+   \param options The CmdOptions object storing the start and end strings from the user.
+   \return 0 if the parsing was successful, -1 otherwise.
+*/
 int32_t const parse_overlap_query(bamit::Position & start,
                                   bamit::Position & end,
                                   CmdOptions const & options,
                                   std::deque<std::string> const & ref_ids)
 {
-    size_t const start_split = options.start.find(':');
-    size_t const end_split = options.end.find(':');
+    // Get the location of the colon in the start and end.
+    size_t const start_split = options.start.find(',');
+    size_t const end_split = options.end.find(',');
     if (start_split == options.start.size() || end_split == options.start.size())
     {
         seqan3::debug_stream << "[ERROR] Start and end positions must be in the format chr_name:position!\n";
         return -1;
     }
-    auto start_ref_id_it = std::find(ref_ids.begin(),
-                                     ref_ids.end(),
-                                     options.start.substr(0, start_split));
-    auto end_ref_id_it = std::find(ref_ids.begin(),
-                                ref_ids.end(),
-                                options.end.substr(0, end_split));
 
-    int32_t start_position{};
-    int32_t end_position{};
+    // Get the iterator position of the chromosomes given.
+    auto start_ref_id_it = std::find(ref_ids.begin(), ref_ids.end(), options.start.substr(0, start_split));
+    auto end_ref_id_it = std::find(ref_ids.begin(), ref_ids.end(), options.end.substr(0, end_split));
     if (start_ref_id_it == ref_ids.end() || end_ref_id_it == ref_ids.end())
     {
         seqan3::debug_stream << "[ERROR] One or both of the chromosome names supplied could not be found.\n";
         return -1;
     }
+
+    // Convert the start and end strings to integers.
+    int32_t start_position{};
+    int32_t end_position{};
     try
     {
         start_position = std::stoi(options.start.substr(start_split + 1));
@@ -46,6 +53,7 @@ int32_t const parse_overlap_query(bamit::Position & start,
         seqan3::debug_stream << "[ERROR] There was a formatting error with the overlap query!\n";
         return -1;
     }
+
     // Convert query string into two Positions.
     int32_t start_ref_id = start_ref_id_it - ref_ids.begin();
     int32_t end_ref_id = end_ref_id_it - ref_ids.begin();
@@ -69,18 +77,18 @@ void initialize_argument_parser(seqan3::argument_parser & parser, CmdOptions & o
 
     // Ref ID regex taken from the SAM format manual.
     std::string ref_id_match{"[0-9A-Za-z!#$%&+./:;?@^_|~-][0-9A-Za-z!#$%&*+./:;=?@^_|~-]*"};
-    seqan3::regex_validator query_validator{ref_id_match + ":[0-9]+"};
+    seqan3::regex_validator query_validator{ref_id_match + ",{1}[0-9]+"};
 
     parser.add_option(options.input_path, 'i', "input_bam",
                       "Input a sorted BAM/SAM file.", seqan3::option_spec::standard,
                       seqan3::input_file_validator{{"sam", "bam"}});
     parser.add_option(options.start, 's', "start",
-                      "The start of the interval to query, in the format chrA:posA."
+                      "The start of the interval to query, in the format chrA,posA."
                       " Note that when start and end are the same, this queries for reads overlapping a point.",
                       seqan3::option_spec::standard,
                       query_validator);
     parser.add_option(options.end, 'e', "end",
-                      "The end of the interval to query, in the format chrB:posB."
+                      "The end of the interval to query, in the format chrB,posB."
                       " Note that when start and end are the same, this queries for reads overlapping a point.",
                       seqan3::option_spec::standard,
                       query_validator);
@@ -104,14 +112,7 @@ int main(int argc, char ** argv)
         return -1;
     }
 
-    using my_fields = seqan3::fields<seqan3::field::id,
-                                     seqan3::field::ref_id,
-                                     seqan3::field::ref_offset,
-                                     seqan3::field::cigar,
-                                     seqan3::field::seq>;
-
     seqan3::debug_stream << "Reading SAM file.\n";
-    seqan3::sam_file_input input{options.input_path, my_fields{}};
 
     seqan3::debug_stream << "Extracting info from reads\n";
 
@@ -126,6 +127,12 @@ int main(int argc, char ** argv)
 
     if (!options.start.empty() && !options.end.empty())
     {
+        using my_fields = seqan3::fields<seqan3::field::id,
+                                         seqan3::field::ref_id,
+                                         seqan3::field::ref_offset,
+                                         seqan3::field::cigar,
+                                         seqan3::field::seq>;
+        seqan3::sam_file_input input{options.input_path, my_fields{}};
         bamit::Position start, end;
         if (parse_overlap_query(start, end, options, input.header().ref_ids()) == -1)
         {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -6,9 +6,53 @@
 struct CmdOptions
 {
     std::filesystem::path input_path{};
-    int32_t start{};
-    int32_t end{};
+    std::string start{};
+    std::string end{};
 };
+
+int32_t const parse_overlap_query(bamit::Position & start,
+                                  bamit::Position & end,
+                                  CmdOptions const & options,
+                                  std::deque<std::string> const & ref_ids)
+{
+    size_t const start_split = options.start.find(':');
+    size_t const end_split = options.end.find(':');
+    if (start_split == options.start.size() || end_split == options.start.size())
+    {
+        seqan3::debug_stream << "[ERROR] Start and end positions must be in the format chr_name:position!\n";
+        return -1;
+    }
+    auto start_ref_id_it = std::find(ref_ids.begin(),
+                                     ref_ids.end(),
+                                     options.start.substr(0, start_split));
+    auto end_ref_id_it = std::find(ref_ids.begin(),
+                                ref_ids.end(),
+                                options.end.substr(0, end_split));
+
+    int32_t start_position{};
+    int32_t end_position{};
+    if (start_ref_id_it == ref_ids.end() || end_ref_id_it == ref_ids.end())
+    {
+        seqan3::debug_stream << "[ERROR] One or both of the chromosome names supplied could not be found.\n";
+        return -1;
+    }
+    try
+    {
+        start_position = std::stoi(options.start.substr(start_split + 1));
+        end_position = std::stoi(options.end.substr(end_split + 1));
+    }
+    catch (...)
+    {
+        seqan3::debug_stream << "[ERROR] There was a formatting error with the overlap query!\n";
+        return -1;
+    }
+    // Convert query string into two Positions.
+    int32_t start_ref_id = start_ref_id_it - ref_ids.begin();
+    int32_t end_ref_id = end_ref_id_it - ref_ids.begin();
+    start = std::make_pair(start_ref_id, start_position);
+    end = std::make_pair(end_ref_id, end_position);
+    return 0;
+}
 
 void initialize_argument_parser(seqan3::argument_parser & parser, CmdOptions & options)
 {
@@ -23,11 +67,23 @@ void initialize_argument_parser(seqan3::argument_parser & parser, CmdOptions & o
     parser.info.short_copyright = "short_copyright";
     parser.info.url = "https://github.com/joshuak94/BAMIntervalTree/";
 
+    // Ref ID regex taken from the SAM format manual.
+    std::string ref_id_match{"[0-9A-Za-z!#$%&+./:;?@^_|~-][0-9A-Za-z!#$%&*+./:;=?@^_|~-]*"};
+    seqan3::regex_validator query_validator{ref_id_match + ":[0-9]+"};
+
     parser.add_option(options.input_path, 'i', "input_bam",
                       "Input a sorted BAM/SAM file.", seqan3::option_spec::standard,
                       seqan3::input_file_validator{{"sam", "bam"}});
-    parser.add_option(options.start, 's', "start", "Start of queried interval");
-    parser.add_option(options.end, 'e', "end", "End of queried interval");
+    parser.add_option(options.start, 's', "start",
+                      "The start of the interval to query, in the format chrA:posA."
+                      " Note that when start and end are the same, this queries for reads overlapping a point.",
+                      seqan3::option_spec::standard,
+                      query_validator);
+    parser.add_option(options.end, 'e', "end",
+                      "The end of the interval to query, in the format chrB:posB."
+                      " Note that when start and end are the same, this queries for reads overlapping a point.",
+                      seqan3::option_spec::standard,
+                      query_validator);
 }
 
 int main(int argc, char ** argv)
@@ -60,8 +116,7 @@ int main(int argc, char ** argv)
     seqan3::debug_stream << "Extracting info from reads\n";
 
     std::vector<bamit::Record> records{};
-    std::vector<uint32_t> cumulative_length{};
-    bamit::parse_file(options.input_path, cumulative_length, records);
+    bamit::parse_file(options.input_path, records);
 
     seqan3::debug_stream << "Creating Interval Tree.\n";
     std::unique_ptr<bamit::IntervalNode> root(nullptr);
@@ -69,11 +124,16 @@ int main(int argc, char ** argv)
 
     root->print(0);
 
-    if (options.start && options.end)
+    if (!options.start.empty() && !options.end.empty())
     {
-        seqan3::debug_stream << "Search: " << options.start << " " << options.end << "\n";
+        bamit::Position start, end;
+        if (parse_overlap_query(start, end, options, input.header().ref_ids()) == -1)
+        {
+            return -1;
+        }
+        seqan3::debug_stream << "Search: " << start << " " << end << "\n";
         std::vector<bamit::Record> results{};
-        bamit::overlap(root, options.start, options.end, results);
+        bamit::overlap(root, start, end, results);
         for (auto & r: results)
             seqan3::debug_stream << r.start << " " << r.end << "\n";
     }

--- a/test/api/construction_test.cpp
+++ b/test/api/construction_test.cpp
@@ -6,9 +6,9 @@
 
 // Recursive function to go through the tree and check the medians.
 void check_medians(std::unique_ptr<bamit::IntervalNode> const & root, int level, int pos,
-                   std::vector<int32_t> const & expected_medians)
+                   std::vector<bamit::Position> const & expected_medians)
 {
-    if (expected_medians[pow(2, level) - 1 + pos] > 0)
+    if (std::get<0>(expected_medians[pow(2, level) - 1 + pos]) != -1)
     {
         EXPECT_EQ(root->get_median(), expected_medians[pow(2, level) - 1 + pos]);
         if(root->get_left_node())
@@ -33,17 +33,24 @@ TEST(tree_construct, simulated_chr1_small_golden)
                                      seqan3::field::seq>;
 
     std::vector<bamit::Record> records{};
-    std::vector<uint32_t> cumulative_length{};
     std::filesystem::path input{DATADIR"simulated_chr1_small_golden.bam"};
-    bamit::parse_file(input, cumulative_length, records);
+    bamit::parse_file(input, records);
 
     std::unique_ptr<bamit::IntervalNode> root(nullptr);
     bamit::construct_tree(root, records);
 
     // Test Tree
-    std::vector<int32_t> expected_medians{944, 467, 1397, 257, 676, 1132, 1664, 140, 363, 571, 802, 1032, 1257,
-                                          1531, 1822, 77, 197, 0, 414, 519, 624, 730, 886, 0, 0, 1194, 1323,
-                                          1464, 1593, 1742, 1928};
+    std::vector<bamit::Position> expected_medians{std::make_pair(0, 944), std::make_pair(0, 467), std::make_pair(0, 1397),
+                                                 std::make_pair(0, 257), std::make_pair(0, 676), std::make_pair(0, 1132),
+                                                 std::make_pair(0, 1664), std::make_pair(0, 140), std::make_pair(0, 363),
+                                                 std::make_pair(0, 571), std::make_pair(0, 802), std::make_pair(0, 1032),
+                                                 std::make_pair(0, 1257), std::make_pair(0, 1531), std::make_pair(0, 1822),
+                                                 std::make_pair(0, 77), std::make_pair(0, 197), std::make_pair(-1, 0),
+                                                 std::make_pair(0, 414), std::make_pair(0, 519), std::make_pair(0, 624),
+                                                 std::make_pair(0, 730), std::make_pair(0, 886), std::make_pair(-1, 0),
+                                                 std::make_pair(-1, 0), std::make_pair(0, 1194), std::make_pair(0, 1323),
+                                                 std::make_pair(0, 1464), std::make_pair(0, 1593), std::make_pair(0, 1742),
+                                                 std::make_pair(0, 1928)};
     check_medians(root, 0, 0, expected_medians);
 }
 
@@ -57,17 +64,24 @@ TEST(tree_construct, simulated_mult_chr_small_golden)
                                      seqan3::field::seq>;
 
     std::vector<bamit::Record> records{};
-    std::vector<uint32_t> cumulative_length{};
     std::filesystem::path input{DATADIR"simulated_mult_chr_small_golden.bam"};
-    bamit::parse_file(input, cumulative_length, records);
+    bamit::parse_file(input, records);
 
     std::unique_ptr<bamit::IntervalNode> root(nullptr);
     bamit::construct_tree(root, records);
 
 
-    std::vector<int32_t> expected_medians{991, 502, 1611, 283, 824, 1276, 1821, 130, 388, 623, 909, 1142, 1505,
-                                          1714, 1938, 71, 196, 336, 448, 563, 759, 0, 0, 1064, 1209, 1450, 1558,
-                                          0, 0, 1885, 2003};
+    std::vector<bamit::Position> expected_medians{std::make_pair(1, 291), std::make_pair(0, 502), std::make_pair(2, 211),
+                                                  std::make_pair(0, 283), std::make_pair(1, 124), std::make_pair(1, 576),
+                                                  std::make_pair(2, 421), std::make_pair(0, 130), std::make_pair(0, 388),
+                                                  std::make_pair(0, 623), std::make_pair(1, 209), std::make_pair(1, 442),
+                                                  std::make_pair(2, 105), std::make_pair(2, 314), std::make_pair(2, 538),
+                                                  std::make_pair(0, 71), std::make_pair(0, 196), std::make_pair(0, 336),
+                                                  std::make_pair(0, 448), std::make_pair(0, 563), std::make_pair(1, 59),
+                                                  std::make_pair(-1, 0), std::make_pair(-1, 0), std::make_pair(1, 364),
+                                                  std::make_pair(1, 509), std::make_pair(2, 50), std::make_pair(2, 158),
+                                                  std::make_pair(-1, 0), std::make_pair(-1, 0), std::make_pair(2, 485),
+                                                  std::make_pair(2, 603)};
     // Test Tree
     check_medians(root, 0, 0, expected_medians);
 }
@@ -84,8 +98,7 @@ TEST(tree_construct, unsorted)
     unsorted_sam.close();
 
     std::vector<bamit::Record> records{};
-    std::vector<uint32_t> cumulative_length{};
-    EXPECT_THROW(bamit::parse_file(unsorted_sam_path, cumulative_length, records), seqan3::format_error);
+    EXPECT_THROW(bamit::parse_file(unsorted_sam_path, records), seqan3::format_error);
 
     std::filesystem::remove(unsorted_sam_path);
 }


### PR DESCRIPTION
Changes the way we handle multiple chromosomes. Instead of calculating a "continuous position" by summing previous chromosome lengths, we now explicitly store the position as a `std::pair` of reference ID and relative position within the chromosome.