### PR TITLE
Reduce space

### DIFF
--- a/include/bamit/IntervalNode.hpp
+++ b/include/bamit/IntervalNode.hpp
@@ -2,20 +2,23 @@
 #include <seqan3/core/debug_stream.hpp>
 #include <seqan3/io/sam_file/input.hpp>
 #include <cereal/types/memory.hpp>
-#include <cereal/types/tuple.hpp>
 #include <cereal/types/vector.hpp>
 
 #include <bamit/Record.hpp>
+
+#include <numeric>
 
 namespace bamit
 {
 /*! The IntervalNode class stores a single node which is a part of an interval tree. It stores a file offset to the
  *  first read which intersects the median, along with pointers to its left and right children.
+ *  Additionally, it stores the chromosome it is in, the start of the left-most record and the end of the right-most
+ *  record.
  */
 class IntervalNode
 {
 private:
-    Position median{};
+    uint32_t start{}, end{}, chr{};
     std::streamoff file_offset{-1};
     std::unique_ptr<IntervalNode> lNode{nullptr};
     std::unique_ptr<IntervalNode> rNode{nullptr};
@@ -50,12 +53,30 @@ public:
      }
 
      /*!
-        \brief Get the median for the current node.
-        \return Returns the median of the current node.
+        \brief Get the start for the current node.
+        \return Returns the start position of the left-most record which is stored in this node.
      */
-     Position const & get_median()
+     uint32_t const & get_start()
      {
-         return median;
+         return start;
+     }
+
+     /*!
+        \brief Get the end for the current node.
+        \return Returns the end position of the right-most record which is stored in this node.
+     */
+     uint32_t const & get_end()
+     {
+         return end;
+     }
+
+     /*!
+        \brief Get the chromosome for the current node.
+        \return Returns the chromosom of the current node.
+     */
+     uint32_t const & get_chr()
+     {
+         return chr;
      }
 
      /*!
@@ -77,12 +98,30 @@ public:
      }
 
      /*!
-        \brief Set the median value for the current node.
-        \param m The calculated median based on the records stored by this node.
+        \brief Set the start value for the current node.
+        \param s The start of the left-most record stored by this node.
      */
-     void set_median(Position m)
+     void set_start(uint32_t s)
      {
-         this->median = std::move(m);
+         this->start = s;
+     }
+
+     /*!
+        \brief Set the end value for the current node.
+        \param e The end of the left-most record stored by this node.
+     */
+     void set_end(uint32_t e)
+     {
+         this->end = e;
+     }
+
+     /*!
+        \brief Set the chromosome value for the current node.
+        \param c The calculated chromosome based on the records stored by this node.
+     */
+     void set_chr(uint32_t c)
+     {
+         this->chr = c;
      }
 
      /*!
@@ -93,8 +132,7 @@ public:
      {
          std::string indent(level, '\t');
          seqan3::debug_stream << indent << "Level: " << level << '\n' <<
-                                 indent << "Median(chromosome, position): " << std::get<0>(this->get_median()) <<
-                                 ", " << std::get<1>(this->get_median()) << '\n' <<
+                                 indent << "Chromosome, start, end: " << chr << ", " << start << ", " << end << '\n' <<
                                  indent << "File offset: " << this->get_file_offset() << '\n';
          if (lNode)
          {
@@ -111,7 +149,7 @@ public:
     template <class Archive>
     void serialize(Archive & ar)
     {
-        ar(median, this->lNode, this->rNode, this->file_offset);
+        ar(this->chr, this->start, this->end, this->lNode, this->rNode, this->file_offset);
     }
 
 };
@@ -119,82 +157,130 @@ public:
 /*!
    \brief Calculate the median for a set of records based on the starts and ends of all records.
    \param records_i The list of records to calculate a median off of.
-   \return Returns the median value and which chromosome it is in.
+   \return Returns a tuple of chromosome of median and the median value.
 
    The median is calculated by sorting all of the starts and ends from a list of records. Since each record
    has a start and end, the list is an even length and the median is the average of the middle two positions.
    If the middle two positions are from the same chromsome, then they are averaged. If they're from two different
    chromosomes then averaging is not possible and the right-most is taken.
 */
-Position calculate_median(std::vector<Record> const & records_i)
+std::tuple<uint32_t, uint32_t> calculate_median(std::vector<std::vector<Record>> const & records_i)
 {
-    std::vector<Position> values{};
-    values.reserve(records_i.size() * 2);
-    Position median{};
-    for (auto const & r : records_i)
+    // Find out which chromosome to use for the median.
+    auto size_calculator = [](int32_t a, std::vector<Record> b) { return a + b.size(); };
+    int32_t middle = std::ceil(std::accumulate(records_i.cbegin(), records_i.cend(), 0, size_calculator) / 2.0);
+
+    uint32_t chr_index{};
+    while (middle > 0)
     {
-        values.push_back(r.start);
-        values.push_back(r.end);
+        middle = middle - records_i[chr_index].size();
+        ++chr_index;
+    }
+    --chr_index;
+
+    // How many reads to the left and right of this chromosome?
+    uint32_t left = (records_i[chr_index] == records_i.front()) ?
+                    0 : std::accumulate(records_i.begin(), records_i.begin() + chr_index, 0, size_calculator);
+    uint32_t right = (records_i[chr_index] == records_i.back()) ?
+                     0 : std::accumulate(records_i.begin() + chr_index + 1, records_i.end(), 0, size_calculator);
+    uint32_t diff_left = left > right ? left - right : 0;
+    uint32_t diff_right = right > left ? right - left : 0;
+
+    std::vector<uint32_t> values{};
+    // If diff_left > 0, can skip that many reads at end of chromosome.
+    // If diff_right > 0, can skip that many reads at start of chromosome.
+    // If they are both == 0, skip no reads.
+    values.reserve((records_i[chr_index].size() - diff_left - diff_right) * 2);
+    for (auto it = records_i[chr_index].cbegin() + diff_right; it != records_i[chr_index].cend() - diff_left; ++it)
+    {
+        values.push_back((*it).start);
+        values.push_back((*it).end);
     }
     std::sort(values.begin(), values.end());
-    size_t size = values.size();
 
-    if (std::get<0>(values[size / 2 - 1]) == std::get<0>(values[size / 2]))
-    {
-        int32_t median_value = (std::get<1>(values[size / 2 - 1]) + std::get<1>(values[size / 2])) / 2;
-        median = std::make_pair(std::get<0>(values[size / 2]), median_value);
-    }
-    else
-    {
-        median = values[size / 2];
-    }
-    return median;
+    return std::make_tuple(chr_index, ((values[values.size() / 2] + values[(values.size() - 1) / 2]) / 2));
 }
 
 /*!
    \brief Construct an interval tree given a set of records.
    \param node The current node to fill.
    \param records_i The list of records to create the tree over.
+   \param offset How many chromosomes are to the left of the current chromosome?
 */
-void construct_tree(std::unique_ptr<IntervalNode> & node, std::vector<Record> const & records_i)
+void construct_tree(std::unique_ptr<IntervalNode> & node,
+                    std::vector<std::vector<Record>> & records_i,
+                    int32_t const offset = 0)
 {
-    if (records_i.empty())
+    // If there are no records, exit.
+    if (records_i.empty() || (records_i.front().empty() && records_i.back().empty()))
     {
         return;
     }
     // Set node to an empty IntervalNode pointer.
     node = std::make_unique<IntervalNode>();
 
-    // Calculate and set median.
-    node->set_median(calculate_median(records_i));
-    Position cur_median = node->get_median();
+    // Calculate and set chromosome.
+    auto [cur_chr, cur_median] = calculate_median(records_i);
+    node->set_chr(cur_chr + offset);
 
     // Get reads which intersect median.
-    std::vector<Record> lRecords{};
-    std::vector<Record> rRecords{};
-    for (auto & r : records_i)
+    std::vector<std::vector<Record>> lRecords{};
+    std::vector<std::vector<Record>> rRecords{};
+
+    // Add initial empty vector to rRecords.
+    rRecords.emplace_back();
+    for (size_t i = 0; i < records_i.size(); ++i)
     {
-        // Median is to the left of the read, so read is in right subtree.
-        if (cur_median < r.start)
+        // Chromosome is less than current chromosome.
+        if (i < cur_chr)
         {
-            rRecords.push_back(std::move(r));
+            lRecords.push_back(std::move(records_i[i]));
         }
-        // Median is to the right of the read, so read is in left subtree.
-        else if (cur_median > r.end)
+        // Chromosome is greater than current chromosome.
+        else if (i > cur_chr)
         {
-            lRecords.push_back(std::move(r));
+            rRecords.push_back(std::move(records_i[i]));
         }
-        // If median is not to the left or right, it must be within the read.
-        // Set the file_offset for this node only if it has not yet been set.
-        else if (node->get_file_offset() == -1)
+        // We are at current chromosome. Reads must be added to current node if they intersect interval.
+        // Otherwise, they should be added to the left/right trees.
+        else
         {
-            node->set_file_offset(r.file_offset);
+            std::vector<Record> l_cur_chr{};
+            uint32_t start{0}, end{0};
+            for (auto & r : records_i[i])
+            {
+                // Read ends before the median.
+                if (r.end < cur_median)
+                {
+                    // Push it back into the first empty vector.
+                    l_cur_chr.push_back(std::move(r));
+                }
+                // Read starts after the median.
+                else if (r.start > cur_median)
+                {
+                    rRecords[0].push_back(std::move(r));
+                }
+                // Read intersects the median. Only store file offset and start from the left-most read!
+                // End is always updated while the read intersects the median.
+                else
+                {
+                    if (node->get_file_offset() == -1)
+                    {
+                        node->set_file_offset(r.file_offset);
+                        start = r.start;
+                    }
+                    end = r.end;
+                }
+            }
+            node->set_start(start);
+            node->set_end(end);
+            lRecords.push_back(std::move(l_cur_chr));
         }
     }
 
     // Set left and right subtrees.
-    construct_tree(node->get_left_node(), lRecords);
-    construct_tree(node->get_right_node(), rRecords);
+    construct_tree(node->get_left_node(), lRecords, offset);
+    construct_tree(node->get_right_node(), rRecords, offset + cur_chr);
     return;
 }
 

--- a/include/bamit/Record.hpp
+++ b/include/bamit/Record.hpp
@@ -42,7 +42,7 @@ auto properly_mapped = std::views::filter([] (auto const & rec)
 /*! A Record object contains pertinent information about an alignment. */
 struct Record
 {
-    uint32_t start, end;
+    uint32_t start{}, end{};
     std::streamoff file_offset{-1};
 
     /*!\name Constructors, destructor and assignment
@@ -146,20 +146,18 @@ void parse_file(std::filesystem::path const & input_path,
         throw seqan3::format_error{"ERROR: Input file must be sorted by coordinate (e.g. samtools sort)"};
     }
 
+    // cur_index, ref_id, and position can never be a negative value because of the properly_mapped filter.
     std::vector<Record> cur_records{};
-    int32_t cur_index{0};
+    uint32_t cur_index{0};
     for (auto const & r : input | properly_mapped)
     {
-        int32_t ref_id = r.reference_id().value();
-        int32_t position = r.reference_position().value();
+        uint32_t ref_id = r.reference_id().value();
+        uint32_t position = r.reference_position().value();
         if (ref_id != cur_index)
         {
-            if (!cur_records.empty())
-            {
-                record_list.push_back(cur_records);
-                cur_records.clear();
-            }
-            cur_index = ref_id;
+            record_list.push_back(cur_records);
+            cur_records.clear();
+            ++cur_index;
         }
         cur_records.emplace_back(r.reference_position().value(),
                                  r.reference_position().value() + get_length(r.cigar_sequence()),

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -96,8 +96,8 @@ int const parse_overlap_query(bamit::Position & start,
     }
 
     // Convert the start and end strings to integers.
-    int32_t start_position{};
-    int32_t end_position{};
+    uint32_t start_position{};
+    uint32_t end_position{};
     try
     {
         start_position = std::stoi(options.start.substr(start_split + 1));
@@ -110,8 +110,8 @@ int const parse_overlap_query(bamit::Position & start,
     }
 
     // Convert query string into two Positions.
-    int32_t start_ref_id = start_ref_id_it - ref_ids.begin();
-    int32_t end_ref_id = end_ref_id_it - ref_ids.begin();
+    uint32_t start_ref_id = start_ref_id_it - ref_ids.begin();
+    uint32_t end_ref_id = end_ref_id_it - ref_ids.begin();
     start = std::make_pair(start_ref_id, start_position);
     end = std::make_pair(end_ref_id, end_position);
     return 0;
@@ -127,7 +127,7 @@ int run_index(std::unique_ptr<bamit::IntervalNode> & root, std::filesystem::path
     seqan3::debug_stream << "Writing to file.\n";
     {
         std::filesystem::path index_path{input};
-        index_path.replace_extension("bit");
+        index_path.replace_extension("bam.bit");
         std::ofstream out_file(index_path,
                                std::ios_base::binary | std::ios_base::out);
         cereal::BinaryOutputArchive archive(out_file);
@@ -146,7 +146,7 @@ int parse_index(seqan3::argument_parser & parser)
     // Parse the given arguments and catch possible errors.
     try
     {
-        parser.parse();                                               // trigger command line parsing
+        parser.parse();                                                 // trigger command line parsing
     }
     catch (seqan3::argument_parser_error const & ext)                   // catch user errors
     {
@@ -168,18 +168,18 @@ int parse_overlap(seqan3::argument_parser & parser)
     // Parse the given arguments and catch possible errors.
     try
     {
-      parser.parse();                                               // trigger command line parsing
+      parser.parse();                                                   // trigger command line parsing
     }
     catch (seqan3::argument_parser_error const & ext)                   // catch user errors
     {
-      seqan3::debug_stream << "[Error] " << ext.what() << '\n';       // customise your error message
+      seqan3::debug_stream << "[Error] " << ext.what() << '\n';         // customise your error message
       return -1;
     }
 
     bamit::sam_file_input_type input{options.input_path};
     std::filesystem::path index_path{options.input_path};
     std::unique_ptr<bamit::IntervalNode> root(nullptr);
-    index_path.replace_extension("bit");
+    index_path.replace_extension("bam.bit");
     if (!std::filesystem::exists(index_path))
     {
         run_index(root, options.input_path);
@@ -218,7 +218,7 @@ int main(int argc, char ** argv)
     // Parse the given arguments and catch possible errors.
     try
     {
-        top_level_parser.parse();                                               // trigger command line parsing
+        top_level_parser.parse();                                       // trigger command line parsing
     }
     catch (seqan3::argument_parser_error const & ext)                   // catch user errors
     {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -119,7 +119,7 @@ int const parse_overlap_query(bamit::Position & start,
 
 int run_index(std::unique_ptr<bamit::IntervalNode> & root, std::filesystem::path const & input)
 {
-    std::vector<bamit::Record> records{};
+    std::vector<std::vector<bamit::Record>> records{};
     bamit::parse_file(input, records);
 
     seqan3::debug_stream << "Creating Interval Tree.\n";

--- a/test/api/search_test.cpp
+++ b/test/api/search_test.cpp
@@ -8,7 +8,7 @@
 TEST(get_overlap_records, simulated_chr1_small_golden)
 {
     // Construct Tree
-    std::vector<bamit::Record> records{};
+    std::vector<std::vector<bamit::Record>> records{};
     std::filesystem::path input{DATADIR"simulated_mult_chr_small_golden.bam"};
     bamit::parse_file(input, records);
 
@@ -28,4 +28,5 @@ TEST(get_overlap_records, simulated_chr1_small_golden)
     EXPECT_RANGE_EQ(expected, result);
 
      std::filesystem::remove(result_sam_path);
+     std::filesystem::remove(input.replace_extension("bam.bit"));
 }

--- a/test/api/write_read_test.cpp
+++ b/test/api/write_read_test.cpp
@@ -18,7 +18,7 @@ TEST(write_read_test, write_read_test)
         // Initialize variables for writing.
         std::ofstream out{tmp, std::ios_base::binary | std::ios_base::out};
         std::unique_ptr<bamit::IntervalNode> root(nullptr);
-        std::vector<bamit::Record> records{};
+        std::vector<std::vector<bamit::Record>> records{};
         cereal::BinaryOutputArchive ar(out);
 
         bamit::parse_file(input, records);


### PR DESCRIPTION
Reduces space for storage and during usage by not storing chromosome information for each record. Also changes the interval nodes to store the start and end of their range, to use in the overlap queries.