### PR TITLE
Change get_overlap_records to return file offset of first read.

### DIFF
--- a/include/bamit/IntervalNode.hpp
+++ b/include/bamit/IntervalNode.hpp
@@ -19,7 +19,7 @@ class IntervalNode
 {
 private:
     uint32_t start{}, end{};
-    std::streamoff file_offset{-1};
+    std::streampos file_offset{-1};
     std::unique_ptr<IntervalNode> lNode{nullptr};
     std::unique_ptr<IntervalNode> rNode{nullptr};
 public:
@@ -72,9 +72,9 @@ public:
 
      /*!
         \brief Get the file offset to the first read stored by this node.
-        \return Returns a reference to a std::streamoff which can be used to seek to a file position.
+        \return Returns a reference to a std::streampos which can be used to seek to a file position.
      */
-     std::streamoff const & get_file_offset()
+     std::streampos const & get_file_offset()
      {
          return file_offset;
      }
@@ -83,7 +83,7 @@ public:
         \brief Set the file offset to the first read for the current node.
         \param new_file_offset The file offset based on the records stored by this node.
      */
-     void set_file_offset(std::streamoff new_file_offset)
+     void set_file_offset(std::streampos new_file_offset)
      {
          this->file_offset = std::move(new_file_offset);
      }
@@ -131,7 +131,7 @@ public:
     template <class Archive>
     void serialize(Archive & ar)
     {
-        ar(this->start, this->end, this->lNode, this->rNode, this->file_offset);
+        ar(this->start, this->end, this->lNode, this->rNode, static_cast<std::streamoff>(this->file_offset));
     }
 
 };
@@ -268,7 +268,7 @@ std::vector<std::unique_ptr<IntervalNode>> index(sam_file_input_type & input_fil
 void get_overlap_file_offset(std::unique_ptr<IntervalNode> const & node,
                              uint32_t const & start,
                              uint32_t const & end,
-                             std::streamoff & offset_pos)
+                             std::streampos & offset_pos)
 {
     if (!node)
     {
@@ -313,7 +313,7 @@ void get_overlap_file_offset(std::unique_ptr<IntervalNode> const & node,
  */
 void get_correct_offset(sam_file_input_type & input,
                         Position const & start,
-                        std::streamoff & offset_pos)
+                        std::streampos & offset_pos)
 {
     input.seek(offset_pos);
     for (auto & r : input | properly_mapped)
@@ -341,13 +341,13 @@ void get_correct_offset(sam_file_input_type & input,
 
    \return Returns the file offset of the first read in the interval, or -1 if no reads are found.
 */
-std::streamoff get_overlap_records(sam_file_input_type & input,
+std::streampos get_overlap_records(sam_file_input_type & input,
                                    std::vector<std::unique_ptr<IntervalNode>> const & node_list,
                                    Position const & start,
                                    Position const & end,
                                    std::filesystem::path const & outname = "")
 {
-    std::streamoff offset_pos{-1};
+    std::streampos offset_pos{-1};
 
     // Look for the file offset using the tree for the starting chromosome.
     if (std::get<0>(start) == std::get<0>(end)) // Searching in one chromosome.

--- a/include/bamit/Record.hpp
+++ b/include/bamit/Record.hpp
@@ -43,7 +43,7 @@ auto properly_mapped = std::views::filter([] (auto const & rec)
 struct Record
 {
     uint32_t start{}, end{};
-    std::streamoff file_offset{-1};
+    std::streampos file_offset{-1};
 
     /*!\name Constructors, destructor and assignment
      * \{
@@ -55,7 +55,7 @@ struct Record
     Record & operator=(Record &&)             = default; //!< Defaulted.
     ~Record()                                 = default; //!< Defaulted.
      //!\}
-    Record(uint32_t start_i, uint32_t end_i, std::streamoff file_offset_i) :
+    Record(uint32_t start_i, uint32_t end_i, std::streampos file_offset_i) :
         start{std::move(start_i)},
         end{std::move(end_i)},
         file_offset{std::move(file_offset_i)} {}

--- a/test/api/write_read_test.cpp
+++ b/test/api/write_read_test.cpp
@@ -22,7 +22,7 @@ TEST(write_read_test, write_read_test)
         cereal::BinaryOutputArchive ar(out);
 
         node_list = bamit::index(sam_in);
-        bamit::get_overlap_file_offset(node_list[std::get<0>(start)], std::get<1>(start), std::get<1>(end), result);
+        result = bamit::get_overlap_records(sam_in, node_list, start, end);
 
         // Write tree to output.
         bamit::write(node_list, ar);
@@ -36,7 +36,7 @@ TEST(write_read_test, write_read_test)
 
         // Read tree from input.
         bamit::read(node_list, ar);
-        bamit::get_overlap_file_offset(node_list[std::get<0>(start)], std::get<1>(start), std::get<1>(end), result_after_reading);
+        result_after_reading = bamit::get_overlap_records(sam_in, node_list, start, end);
         in.close();
     }
 

--- a/test/api/write_read_test.cpp
+++ b/test/api/write_read_test.cpp
@@ -8,8 +8,8 @@
 TEST(write_read_test, write_read_test)
 {
     std::filesystem::path tmp = std::filesystem::temp_directory_path()/"intervaltree";
-    std::streamoff result{-1};
-    std::streamoff result_after_reading{-1};
+    std::streampos result{-1};
+    std::streampos result_after_reading{-1};
     bamit::Position start{1, 100};
     bamit::Position end{1, 150};
     std::filesystem::path input{DATADIR"simulated_mult_chr_small_golden.bam"};

--- a/test/benchmark/benchmark_api.cpp
+++ b/test/benchmark/benchmark_api.cpp
@@ -87,7 +87,7 @@ TEST(benchmark, construct_and_search)
 
     // Generate 100 overlaps.
     bamit::Position start, end;
-    std::streamoff result{-1};
+    std::streampos result{-1};
     bamit::sam_file_input_type input_bam_2{large_file};
     for (int i = 0; i < 100; i++)
     {

--- a/test/benchmark/benchmark_api.cpp
+++ b/test/benchmark/benchmark_api.cpp
@@ -98,7 +98,7 @@ TEST(benchmark, construct_and_search)
                                 std::to_string(std::get<1>(end)) + "]"};
         RUN(bamit::get_overlap_records(input_bam_2, node_list, start, end, result_sam_path),
             query + " writing");
-        RUN(bamit::get_overlap_file_offset(node_list[std::get<0>(start)], std::get<1>(start), std::get<1>(end), result),
+        RUN(bamit::get_overlap_records(input_bam_2, node_list, start, end),
             query + " offest");
         std::filesystem::remove(result_sam_path);
     }


### PR DESCRIPTION
Now, `get_overlap_records` will be the main function for overlap queries, and `get_overlap_file_offset` will just be an internal one. 