### PR TITLE
[MISC] Update doxygen & submodule seqan3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,42 +86,6 @@ jobs:
             build_type: Release
             cxx_flags: "-std=c++20"
 
-          - name: "gcc8 on Linux"
-            os: ubuntu-20.04
-            requires_toolchain: true
-            requires_ccache: true
-            cxx: "g++-8"
-            cc: "gcc-8"
-            build: unit
-            build_type: Release
-
-          - name: "gcc8 on macOS"
-            os: macos-10.15
-            requires_toolchain: true
-            requires_ccache: true
-            cxx: "g++-8"
-            cc: "gcc-8"
-            build: unit
-            build_type: Release
-
-          - name: "gcc7 on Linux"
-            os: ubuntu-20.04
-            requires_toolchain: true
-            requires_ccache: true
-            cxx: "g++-7"
-            cc: "gcc-7"
-            build: unit
-            build_type: Release
-
-          - name: "gcc7 on macOS"
-            os: macos-10.15
-            requires_toolchain: true
-            requires_ccache: true
-            cxx: "g++-7"
-            cc: "gcc-7"
-            build: unit
-            build_type: Release
-
           - name: "Documentation"
             os: ubuntu-20.04
             requires_toolchain: false

--- a/doc/doxygen_cfg
+++ b/doc/doxygen_cfg
@@ -2310,15 +2310,6 @@ EXTERNAL_PAGES         = YES
 # Configuration options related to the dot tool
 #---------------------------------------------------------------------------
 
-# If the CLASS_DIAGRAMS tag is set to YES, doxygen will generate a class diagram
-# (in HTML and LaTeX) for classes with base or super classes. Setting the tag to
-# NO turns the diagrams off. Note that this option also works with HAVE_DOT
-# disabled, but it is recommended to install and use dot, since it yields more
-# powerful graphs.
-# The default value is: YES.
-
-CLASS_DIAGRAMS         = YES
-
 # You can include diagrams made with dia in doxygen documentation. Doxygen will
 # then run dia to produce the diagram and insert it in the documentation. The
 # DIA_PATH tag allows you to specify the directory where the dia binary resides.
@@ -2377,7 +2368,6 @@ DOT_FONTPATH           =
 
 # If the CLASS_GRAPH tag is set to YES then doxygen will generate a graph for
 # each documented class showing the direct and indirect inheritance relations.
-# Setting this tag to YES will force the CLASS_DIAGRAMS tag to NO.
 # The default value is: YES.
 # This tag requires that the tag HAVE_DOT is set to YES.
 

--- a/test/cli/cli_test.hpp
+++ b/test/cli/cli_test.hpp
@@ -1,9 +1,9 @@
 #include <gtest/gtest.h>
 
-#include <cstdlib>               // system calls
-#include <seqan3/std/filesystem> // test directory creation
-#include <sstream>               // ostringstream
-#include <string>                // strings
+#include <cstdlib>      // system calls
+#include <filesystem>   // test directory creation
+#include <sstream>      // ostringstream
+#include <string>       // strings
 
 // Include the EXPECT_RANGE_EQ macro for better information if range elements differ.
 #include <seqan3/test/expect_range_eq.hpp>


### PR DESCRIPTION
- [DOC] Update doxygen to 1.9.3 and fix warnings
- [INFRA] Update submodule seqan3 and replace include <seqan3/std/filesystem> with <filesystem>
- [INFRA] Remove gcc/g++ 7 and 8 support.

as `"SeqAn 3.1.x is the last version that supports GCC 7 and 8. Please upgrade your compiler or use 3.1.x."`
I removed GCC 7 and 8 aswell